### PR TITLE
Fixed a syntax error

### DIFF
--- a/code/hacks.php
+++ b/code/hacks.php
@@ -86,7 +86,7 @@
             'version' => 'Firefox 3+',
             'data-version' => '3+',
             'language' => 'language-css',
-            'code' => ".selector, x:-moz-any-link; x:default {}"
+            'code' => ".selector, x:-moz-any-link, x:default {}"
           ),
           array (
             'version' => 'Firefox 3.5+',


### PR DESCRIPTION
The Firefox 3 rule has a semicolon that does not exist anywhere else (browserhacks-tests.css, for example). I did not check, but it looks wrong and unreliable anyway, so I replaced it with a comma.
