### PR TITLE
Add hack for Firefox ≥ 35

### DIFF
--- a/src/db/hacks.json
+++ b/src/db/hacks.json
@@ -406,6 +406,21 @@
     "safe": false
   },
   {
+    "type": "supports",
+    "browsers": {
+      "fx": "35+"
+    },
+    "label": "",
+    "language": "css",
+    "code": [
+      "@supports (-moz-appearance:meterbar) and (filter:opacity(1)) {}"
+    ],
+    "test": [
+      "@supports (-moz-appearance:meterbar) and (filter:opacity(1)) { .selector { background: lightgreen; } }"
+    ],
+    "safe": false
+  },
+  {
     "type": "javascript",
     "browsers": {
       "fx": "*"


### PR DESCRIPTION
This hack is based on CSS filter support.
https://www.mozilla.org/en-US/firefox/35.0a2/auroranotes/#note-785750

It should be very useful as Firefox ≥ 35 finally supports -moz-appearance: none on select elements.
