### PR TITLE
Update Supports Hacks

### DIFF
--- a/src/db/hacks.json
+++ b/src/db/hacks.json
@@ -21,6 +21,7 @@
     "type": "supports",
     "browsers": {
       "ch": "28+",
+      "sa": "9+",
       "op": "14+"
     },
     "label": "",


### PR DESCRIPTION
Safari supports `@supports` from 9. [via](http://caniuse.com/#search=supports)
